### PR TITLE
Removed generating licenses of pom children

### DIFF
--- a/src/main/groovy/com/github/jk1/license/reader/ConfigurationReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/reader/ConfigurationReader.groovy
@@ -50,7 +50,9 @@ class ConfigurationReader {
                 LOGGER.debug("Not collecting dependency ${root.name} due to explicit exclude configured")
                 accumulator.add(root)
             }
-            root.children.each {collectDependencies(accumulator, it)}
+            root.children.each(){
+                LOGGER.debug("Not including dependency child ${it.name}")
+            }
         }
         accumulator
     }

--- a/src/main/groovy/com/github/jk1/license/reader/PomReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/reader/PomReader.groovy
@@ -1,10 +1,6 @@
 package com.github.jk1.license.reader
 
-import com.github.jk1.license.License
-import com.github.jk1.license.PomData
-import com.github.jk1.license.PomDeveloper
-import com.github.jk1.license.PomOrganization
-import com.github.jk1.license.ReportTask
+import com.github.jk1.license.*
 import com.github.jk1.license.util.CachingArtifactResolver
 import com.github.jk1.license.util.Files
 import groovy.util.slurpersupport.GPathResult
@@ -138,7 +134,8 @@ class PomReader {
 
         pomData.name = pomContent.name?.text()
         pomData.description = pomContent.description?.text()
-        pomData.projectUrl = pomContent.url?.text()
+        String projectUrl = pomContent.url?.text()
+        pomData.projectUrl = (projectUrl == null || projectUrl.isEmpty()) ? pomData.projectUrl : projectUrl
         pomData.inceptionYear = pomContent.inceptionYear?.text()
 
         def organizationName = pomContent.organization?.name?.text()


### PR DESCRIPTION
Because it generated one license per each module within a library, which is not required.
We only want one license per library and we do not care aobut the lirbary's dependencies.

Fixed rewriting of project url with empty values. Usually it made sense to use the last valid non-empty url.